### PR TITLE
Add rail bridge end model and name adjustments

### DIFF
--- a/src/main/resources/assets/mcwbridges/lang/en_us.lang
+++ b/src/main/resources/assets/mcwbridges/lang/en_us.lang
@@ -45,11 +45,17 @@ tile.orange_sandstone_bridge.name=Red Sandstone Bridge
 tile.orange_sandstone_bridge_end.name=Red Sandstone Bridge End
 
 tile.oak_rail_bridge.name=Oak Rail Bridge
+tile.oak_rail_bridge_end.name=Oak Rail Bridge End
 tile.spruce_rail_bridge.name=Spruce Rail Bridge
+tile.spruce_rail_bridge_end.name=Spruce Rail Bridge End
 tile.birch_rail_bridge.name=Birch Rail Bridge
+tile.birch_rail_bridge_end.name=Birch Rail Bridge End
 tile.jungle_rail_bridge.name=Kapok Rail Bridge
+tile.jungle_rail_bridge_end.name=Kapok Rail Bridge End
 tile.acacia_rail_bridge.name=Acacia Rail Bridge
+tile.acacia_rail_bridge_end.name=Acacia Rail Bridge End
 tile.dark_oak_rail_bridge.name=Hickory Rail Bridge
+tile.dark_oak_rail_bridge_end.name=Hickory Rail Bridge End
 tile.oak_rail_bridge_powered.name=Powered Oak Rail Bridge
 tile.spruce_rail_bridge_powered.name=Powered Spruce Rail Bridge
 tile.birch_rail_bridge_powered.name=Powered Birch Rail Bridge

--- a/src/main/resources/assets/mcwbridges/models/block/acacia_rail_bridge_end.json
+++ b/src/main/resources/assets/mcwbridges/models/block/acacia_rail_bridge_end.json
@@ -1,0 +1,9 @@
+{
+	"parent": "mcwbridges:block/parent/rail_bridge_end",
+	"textures": {
+		"5": "tfc:blocks/wood/planks/acacia",
+		"2": "tfc:blocks/wood/log/acacia",
+		"6": "tfc:blocks/wood/top/acacia",
+		"particle": "tfc:blocks/wood/log/acacia"
+	}
+}

--- a/src/main/resources/assets/mcwbridges/models/block/birch_rail_bridge_end.json
+++ b/src/main/resources/assets/mcwbridges/models/block/birch_rail_bridge_end.json
@@ -1,0 +1,9 @@
+{
+	"parent": "mcwbridges:block/parent/rail_bridge_end",
+	"textures": {
+		"5": "tfc:blocks/wood/planks/birch",
+		"2": "tfc:blocks/wood/log/birch",
+		"6": "tfc:blocks/wood/top/birch",
+		"particle": "tfc:blocks/wood/log/birch"
+	}
+}

--- a/src/main/resources/assets/mcwbridges/models/block/dark_oak_rail_bridge_end.json
+++ b/src/main/resources/assets/mcwbridges/models/block/dark_oak_rail_bridge_end.json
@@ -1,0 +1,9 @@
+{
+	"parent": "mcwbridges:block/parent/rail_bridge_end",
+	"textures": {
+		"5": "tfc:blocks/wood/planks/hickory",
+		"2": "tfc:blocks/wood/log/hickory",
+		"6": "tfc:blocks/wood/top/hickory",
+		"particle": "tfc:blocks/wood/log/hickory"
+	}
+}

--- a/src/main/resources/assets/mcwbridges/models/block/jungle_rail_bridge_end.json
+++ b/src/main/resources/assets/mcwbridges/models/block/jungle_rail_bridge_end.json
@@ -1,0 +1,9 @@
+{
+	"parent": "mcwbridges:block/parent/rail_bridge_end",
+	"textures": {
+		"5": "tfc:blocks/wood/planks/kapok",
+		"2": "tfc:blocks/wood/log/kapok",
+		"6": "tfc:blocks/wood/top/kapok",
+		"particle": "tfc:blocks/wood/log/kapok"
+	}
+}

--- a/src/main/resources/assets/mcwbridges/models/block/oak_rail_bridge_end.json
+++ b/src/main/resources/assets/mcwbridges/models/block/oak_rail_bridge_end.json
@@ -1,0 +1,9 @@
+{
+	"parent": "mcwbridges:block/parent/rail_bridge_end",
+	"textures": {
+		"5": "tfc:blocks/wood/planks/oak",
+		"2": "tfc:blocks/wood/log/oak",
+		"6": "tfc:blocks/wood/top/oak",
+		"particle": "tfc:blocks/wood/log/oak"
+	}
+}

--- a/src/main/resources/assets/mcwbridges/models/block/spruce_rail_bridge_end.json
+++ b/src/main/resources/assets/mcwbridges/models/block/spruce_rail_bridge_end.json
@@ -1,0 +1,9 @@
+{
+	"parent": "mcwbridges:block/parent/rail_bridge_end",
+	"textures": {
+		"5": "tfc:blocks/wood/planks/spruce",
+		"2": "tfc:blocks/wood/log/spruce",
+		"6": "tfc:blocks/wood/top/spruce",
+		"particle": "tfc:blocks/wood/log/spruce"
+	}
+}


### PR DESCRIPTION
Fixes mismatched names and textures for rail bridge ends.

Model file changes are from Xelbayria via ACGaming.